### PR TITLE
Drop temperal method renaming napa_binding.node.

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -18,10 +18,6 @@ function checkNodeVersion() {
     }
 }
 
-if (typeof __in_napa === 'undefined') {
-    checkNodeVersion();
-    module.exports = require('../bin/napa-binding');
-} else {
-    checkNodeVersion();
-    module.exports = require('../bin/napa-binding-napa');
-}
+checkNodeVersion();
+module.exports = require('../bin/napa-binding');
+

--- a/node/addon.cpp
+++ b/node/addon.cpp
@@ -49,4 +49,4 @@ void InitAll(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {
     NAPA_SET_METHOD(exports, "shutdown", Shutdown);
 }
 
-NAPA_MODULE(addon, InitAll)
+NAPA_MODULE(napa_binding, InitAll)


### PR DESCRIPTION
Also change napa_binding's name from addon to its correct form.
Should be together used with node's module loader that binary addon load multiple times.